### PR TITLE
Use java toolchain

### DIFF
--- a/depstoml/build.gradle.kts
+++ b/depstoml/build.gradle.kts
@@ -37,6 +37,12 @@ dependencies {
     testImplementation(libs.kotlin.test)
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions {
         jvmTarget = "17"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Java and Kotlin language versions to 17. 

### Detailed summary:
- Added `java` block to `build.gradle.kts` file
- Set language version to 17 in `java` block
- Updated `jvmTarget` to 17 for Kotlin compilation tasks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->