### PR TITLE
Add --replace-usages flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Sample toml value: `gradle/libs.versions.toml`
 
 #### Options
 - `-o`, `--order-lexicographically` - if you want to sort the dependencies lexicographically
+- `-r`, `--replace-usages` - if you want to replace usages of old dependencies with new ones in build.gradle.kts files
 
 #### Arguments
 - `deps` - path to Kotlin dependencies file

--- a/depstoml/build.gradle.kts
+++ b/depstoml/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "by.overpass"
-version = "0.1"
+version = "0.2"
 
 application {
     mainClass.set("by.overpass.depstoml.MainKt")

--- a/depstoml/src/main/kotlin/by/overpass/depstoml/DepsTreeNode.kt
+++ b/depstoml/src/main/kotlin/by/overpass/depstoml/DepsTreeNode.kt
@@ -96,7 +96,7 @@ private fun MutableList<MutableList<String>>.format(orderLexicographically: Bool
             if (path.matches(libraryRegex) || path.matches(pluginRegex)) {
                 formattedList += path
             } else {
-                formattedList += separateIds(this[i][j])
+                formattedList += separateIds(path)
             }
         }
         this[i] = formattedList
@@ -104,6 +104,25 @@ private fun MutableList<MutableList<String>>.format(orderLexicographically: Bool
     if (orderLexicographically) {
         sortBy(MutableList<String>::joinToString)
     }
+}
+
+fun DepsTreeNode.findReplacements(): Map<String, String> = getAllLeafPaths()
+    .findReplacements()
+
+private fun List<List<String>>.findReplacements(): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+    for (path in this) {
+        val oldIdentifier = path
+            .subList(1, path.size - 1)
+            .joinToString(".")
+        val newPath = mutableListOf("libs")
+        for (j in 2 until path.size - 1) {
+            newPath += separateIds(path[j])
+        }
+        val newIdentifier = newPath.joinToString(".")
+        map += oldIdentifier to newIdentifier
+    }
+    return map
 }
 
 private fun createVersion(path: List<String>): Version {

--- a/depstoml/src/main/kotlin/by/overpass/depstoml/ReplaceAll.kt
+++ b/depstoml/src/main/kotlin/by/overpass/depstoml/ReplaceAll.kt
@@ -1,0 +1,15 @@
+package by.overpass.depstoml
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+fun Path.replaceAll(replacements: Map<String, String>) {
+    var fileString = Files.readString(this)
+    if (replacements.keys.none(fileString::contains)) {
+        return
+    }
+    for ((old, new) in replacements) {
+        fileString = fileString.replace(old, new)
+    }
+    Files.writeString(this, fileString)
+}

--- a/depstoml/src/test/kotlin/by/overpass/depstoml/ConversionTest.kt
+++ b/depstoml/src/test/kotlin/by/overpass/depstoml/ConversionTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class DepstomlTest {
+class ConversionTest {
 
     private val tomlPath = "build/generated/main/kotlin/by/overpass/depstoml/libs.versions.toml"
 

--- a/depstoml/src/test/kotlin/by/overpass/depstoml/ReplacementTest.kt
+++ b/depstoml/src/test/kotlin/by/overpass/depstoml/ReplacementTest.kt
@@ -1,0 +1,85 @@
+package by.overpass.depstoml
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.io.path.Path
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ReplacementTest(
+    private val dependenciesFilePath: String,
+    buildGradlePath: String,
+    private val expected: String,
+) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> = listOf(
+            arrayOf(
+                "src/test/resources/DependenciesFile.kt",
+                "src/test/resources/gradle/dependencies/build.gradle.kts",
+                """ |plugins {
+                    |    alias(libs.plugins.ksp)
+                    |}
+                    |
+                    |dependencies {
+                    |    implementation(libs.kotlin.gradle.plugin)
+                    |    implementation(libs.kotlin.date.time)
+                    |    implementation(libs.kotlin.coroutines.core)
+                    |    implementation(libs.log.napier)
+                    |    testImplementation(libs.kotlin.coroutines.test)
+                    |}
+                    |""".trimMargin(),
+            ),
+            arrayOf(
+                "src/test/resources/VersionsAndDependenciesFile.kt",
+                "src/test/resources/gradle/versions-and-dependencies/build.gradle.kts",
+                """ |plugins {
+                    |    alias(libs.plugins.ksp)
+                    |}
+                    |
+                    |dependencies {
+                    |    implementation(libs.kotlin.gradle.plugin)
+                    |    implementation(libs.kotlin.date.time)
+                    |    implementation(libs.kotlin.coroutines.core)
+                    |    implementation(libs.log.napier)
+                    |    testImplementation(libs.kotlin.coroutines.test)
+                    |}
+                    |""".trimMargin(),
+            ),
+        )
+    }
+
+    private val tomlPath = "build/generated/main/kotlin/by/overpass/depstoml/libs.versions.toml"
+    private val buildGradlePath = Path(buildGradlePath)
+    private val initialBuildGradleText = Files.readString(this.buildGradlePath)
+
+    private val depstomlCommand = ConvertDependenciesToToml()
+
+    @Test
+    fun `usages are replaced in build gradle kts`() {
+        depstomlCommand.main(
+            arrayOf(
+                dependenciesFilePath,
+                "-r",
+                tomlPath,
+            ),
+        )
+
+        val actual = Files.readString(buildGradlePath)
+
+        assertEquals(expected, actual)
+    }
+
+    @AfterTest
+    fun teardown() {
+        File(tomlPath).delete()
+        Files.writeString(buildGradlePath, initialBuildGradleText)
+    }
+}

--- a/depstoml/src/test/resources/gradle/dependencies/build.gradle.kts
+++ b/depstoml/src/test/resources/gradle/dependencies/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(Dependencies.Plugins.ksp)
+}
+
+dependencies {
+    implementation(Dependencies.Kotlin.gradlePlugin)
+    implementation(Dependencies.Kotlin.dateTime)
+    implementation(Dependencies.Kotlin.Coroutines.core)
+    implementation(Dependencies.Log.napier)
+    testImplementation(Dependencies.Kotlin.Coroutines.test)
+}

--- a/depstoml/src/test/resources/gradle/versions-and-dependencies/build.gradle.kts
+++ b/depstoml/src/test/resources/gradle/versions-and-dependencies/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(Deps.Plugins.ksp)
+}
+
+dependencies {
+    implementation(Deps.Kotlin.gradlePlugin)
+    implementation(Deps.Kotlin.dateTime)
+    implementation(Deps.Kotlin.Coroutines.core)
+    implementation(Deps.Log.napier)
+    testImplementation(Deps.Kotlin.Coroutines.test)
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new feature to the `depstoml` Gradle plugin that allows users to replace usages of old dependencies with new ones in `build.gradle.kts` files. 

### Detailed summary
- Added `-r`, `--replace-usages` command line option to `depstoml` Gradle plugin
- Added `replaceAll` function to `Path` class to replace all occurrences of old dependency identifiers with new ones in a file
- Added `findReplacements` function to `DepsTreeNode` class to find all old and new dependency identifiers
- Added `ReplacementTest` class to test the new feature

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->